### PR TITLE
Bump elliptic version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,48 +1,81 @@
 {
-  "name": "bitcore",
+  "name": "bitcore-lib-zen",
   "version": "0.13.19",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "bn.js": {
       "version": "2.0.4",
-      "from": "bn.js@=2.0.4",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz",
+      "integrity": "sha1-Igp81nf38b+pNif/QZN3b+eBlIA="
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "bs58": {
       "version": "2.0.0",
-      "from": "bs58@=2.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz",
+      "integrity": "sha1-crcTvtIjoKxRi72g484/SBfznrU="
     },
     "buffer-compare": {
       "version": "1.0.0",
-      "from": "buffer-compare@=1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
+      "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
     },
     "elliptic": {
-      "version": "3.0.3",
-      "from": "elliptic@=3.0.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
-      "dependencies": {
-        "brorand": {
-          "version": "1.0.5",
-          "from": "brorand@^1.0.1",
-          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
-        },
-        "hash.js": {
-          "version": "1.0.3",
-          "from": "hash.js@=1.0.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
-        }
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@=2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "lodash": {
       "version": "4.17.15",
-      "from": "lodash@=4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bn.js": "=2.0.4",
     "bs58": "=2.0.0",
     "buffer-compare": "=1.0.0",
-    "elliptic": "=3.0.3",
+    "elliptic": "=6.5.3",
     "inherits": "=2.0.1",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
Verified that the bump of the elliptic version did not break anything but after looking at https://github.com/HorizenOfficial/bitcore-lib-zen/pull/10 I noticed that the npm-shrinkwrap.json had over 11K changes.  When I compiled the npm-shrinkwrap it only had 83 changes.

This pull request is to bump the elliptic version and npm-shrinkwrap